### PR TITLE
coreboot: add export of coreboot timestamps table

### DIFF
--- a/drivers/firmware/coreboot/Kconfig
+++ b/drivers/firmware/coreboot/Kconfig
@@ -15,7 +15,7 @@ config COREBOOT_SYSFS
 config COREBOOT_TIMESTAMPS
 	tristate "Coreboot timestamps table"
 	default n
-	depends on GOOGLE_COREBOOT_TABLE
+	depends on COREBOOT_SYSFS && GOOGLE_COREBOOT_TABLE
 	help
 	  This driver exportes coreboot timestamps table
 	  to /sys/firmware/coreboot/timestamps

--- a/drivers/firmware/coreboot/Kconfig
+++ b/drivers/firmware/coreboot/Kconfig
@@ -10,6 +10,14 @@ config COREBOOT_SYSFS
 	tristate "Coreboot sysfs driver"
 	default n
 	help
-	  This driver create coreboot node in /sys/firmware
+	  This driver creates coreboot node in /sys/firmware
+
+config COREBOOT_TIMESTAMPS
+	tristate "Coreboot timestamps table"
+	default n
+	depends on GOOGLE_COREBOOT_TABLE
+	help
+	  This driver exportes coreboot timestamps table
+	  to /sys/firmware/coreboot/timestamps
 
 endif # COREBOOT_TABLES

--- a/drivers/firmware/coreboot/Makefile
+++ b/drivers/firmware/coreboot/Makefile
@@ -1,1 +1,2 @@
 obj-$(CONFIG_COREBOOT_SYSFS)		+= coreboot_sysfs.o
+obj-$(CONFIG_COREBOOT_TIMESTAMPS)	+= coreboot_timestamps.o

--- a/drivers/firmware/coreboot/coreboot_timestamps.c
+++ b/drivers/firmware/coreboot/coreboot_timestamps.c
@@ -1,0 +1,249 @@
+#include <linux/init.h>
+#include <linux/sysfs.h>
+#include <linux/kobject.h>
+#include <linux/module.h>
+#include <linux/cpufreq.h>
+#include <linux/slab.h>
+
+#include "timestamp.h"
+
+// TODO: rework this ?? how ??
+#include <../drivers/firmware/google/coreboot_table.h>
+
+#define CB_TAG_TIMESTAMPS   0x0016
+
+extern struct kobject *cb_kobj;
+static struct timestamp_table *ts_tbl;
+static unsigned long tick_freq_mhz;
+
+static char *ts_tbl_buf;
+static uint32_t curr_ts_tbl_buf_indx;
+#define PARSED_TS_TBL_SIZE (4096)
+
+static ssize_t ts_tbl_read(struct file *filp, struct kobject *kobp,
+			       struct bin_attribute *bin_attr, char *buf,
+			       loff_t pos, size_t count)
+{
+	pr_debug("ts_tbl_read() \n");
+
+	return memory_read_from_buffer(buf, count, &pos,
+				ts_tbl_buf, curr_ts_tbl_buf_indx);
+}
+
+static struct bin_attribute ts_tbl_bin_attr = {
+	.attr = {.name = "timestamps", .mode = 0444},
+	.read = ts_tbl_read,
+};
+
+static int ts_set_tick_freq(unsigned long table_tick_freq_mhz)
+{
+	int ret = 0;
+
+	tick_freq_mhz = table_tick_freq_mhz;
+
+	if (!tick_freq_mhz) {
+//		tick_freq_mhz = arch_set_tick_frequency();
+		struct cpufreq_policy *cpufreq_policy;
+
+//		pr_info("cpu_khz = %d\n", cpu_khz);
+
+		cpufreq_policy = cpufreq_cpu_get(0);
+		if (cpufreq_policy) {
+			pr_debug("max1 = %d, max2 = %d\n",
+				cpufreq_policy->max,
+				cpufreq_policy->cpuinfo.max_freq);
+
+			tick_freq_mhz = cpufreq_policy->cpuinfo.max_freq;
+
+			cpufreq_cpu_put(cpufreq_policy);
+		} else {
+			pr_debug("cpufreq policy is NULL; looks like U are "
+				"using QEMU\n");
+			// for QEMU case where there is no scaling, seems that
+			// cpu_khz is the maximum frequency
+			tick_freq_mhz = cpu_khz / 1000;
+		}
+
+		ret = 1;
+	}
+
+	if (!tick_freq_mhz) {
+		pr_err("Cannot determine timestamp tick frequency\n");
+		ret = 0;
+	}
+
+	pr_debug("Timestamp tick frequency: %ld MHz\n", tick_freq_mhz);
+
+	return ret;
+}
+
+static int cb_ts_tbl_map(phys_addr_t physaddr)
+{
+	size_t size;
+
+	size = sizeof(*ts_tbl);
+	ts_tbl = memremap(physaddr, size, MEMREMAP_WB);
+	if (!ts_tbl) {
+		pr_err("(1) timestamp table could not be mapped\n");
+		return -ENOMEM;
+	}
+
+	pr_debug("number of entries in coreboot timestamp table: %d\n", ts_tbl->num_entries);
+
+	size += ts_tbl->num_entries * sizeof(ts_tbl->entries[0]);
+
+	pr_debug("size of coreboot timestamp table: 0x%lx\n", size);
+
+	if (!ts_set_tick_freq(ts_tbl->tick_freq_mhz)) {
+		memunmap(ts_tbl);
+		return -EINVAL;
+	}
+
+	memunmap(ts_tbl);
+
+	ts_tbl = memremap(physaddr, size, MEMREMAP_WB);
+	if (!ts_tbl) {
+		pr_err("(2) timestamp table could not be mapped\n");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+uint64_t convert_raw_ts_entry(uint64_t ts)
+{
+	return ts / tick_freq_mhz;
+}
+
+static const char *ts_name(uint32_t id)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(timestamp_ids); i++) {
+		if (timestamp_ids[i].id == id)
+			return timestamp_ids[i].name;
+	}
+
+	return "<unknown>";
+}
+
+static void write_to_ts_tbl_buf(const char *fmt, ...)
+{
+	va_list args;
+	uint32_t curr_ts_tbl_buf_size = PARSED_TS_TBL_SIZE - curr_ts_tbl_buf_indx;
+
+	if (!curr_ts_tbl_buf_size)
+		pr_warn("too small buffer for timestamp table\n");
+
+	va_start(args, fmt);
+	curr_ts_tbl_buf_indx += vsnprintf(ts_tbl_buf + curr_ts_tbl_buf_indx,
+				curr_ts_tbl_buf_size,
+				fmt,
+				args);
+	va_end(args);
+}
+
+static uint64_t ts_get_entry(uint32_t id, uint64_t stamp, uint64_t prev_stamp)
+{
+	const char *name;
+	uint64_t step_time;
+
+	name = ts_name(id);
+
+	step_time = convert_raw_ts_entry(stamp - prev_stamp);
+
+	/* ID<tab>absolute time<tab>relative time<tab>description */
+	pr_debug("%d\t", id);
+	pr_debug("%llu\t", convert_raw_ts_entry(stamp));
+	pr_debug("%llu\t", step_time);
+	pr_debug("%s\n", name);
+
+	write_to_ts_tbl_buf("%d\t%llu\t\t%llu\t\t%s\n",
+			id, convert_raw_ts_entry(stamp),
+			step_time, name);
+
+	return step_time;
+}
+
+void parse_ts_table(void)
+{
+	uint64_t prev_stamp = 0;
+	uint64_t total_time = 0;
+	int i;
+
+	write_to_ts_tbl_buf("%s\t%s\t%s\t%s\n",
+			"ID", "Absolute time", "Relative time", "Description");
+
+	/* Report the base time within the table. */
+	ts_get_entry(0,  ts_tbl->base_time, prev_stamp);
+
+	for (i = 0; i < ts_tbl->num_entries; i++) {
+		uint64_t stamp;
+		const struct timestamp_entry *tse = &ts_tbl->entries[i];
+
+		/* Make all timestamps absolute. */
+		stamp = tse->entry_stamp + ts_tbl->base_time;
+		total_time += ts_get_entry(tse->entry_id, stamp, prev_stamp);
+		prev_stamp = stamp;
+	}
+}
+
+static int __init cb_ts_tbl_init(void)
+{
+	int ret;
+	struct lb_cbmem_ref entry;
+
+	pr_debug("cb_ts_tbl_init()\n");
+
+	ret = coreboot_table_find(CB_TAG_TIMESTAMPS, &entry, sizeof(entry));
+	if (ret) {
+		pr_err("timestamp table was not found\n");
+		return ret;
+	}
+
+	pr_debug("tag: 0x%x, size: 0x%x, cbmem_addr: 0x%llx\n",
+		entry.tag,
+		entry.size,
+		entry.cbmem_addr);
+
+	ret = cb_ts_tbl_map(entry.cbmem_addr);
+	if (ret) {
+		pr_err("coreboot timestamp table was not mapped\n");
+		return ret;
+	}
+
+	ts_tbl_buf = kzalloc(PARSED_TS_TBL_SIZE, GFP_KERNEL);
+	if (!ts_tbl_buf) {
+		pr_err("memory for parsed timestamp table was not allocated\n");
+		memunmap(ts_tbl);
+		return -ENOMEM;
+	}
+
+	curr_ts_tbl_buf_indx = 0;
+	parse_ts_table();
+
+	memunmap(ts_tbl);
+
+	ret = sysfs_create_bin_file(cb_kobj, &ts_tbl_bin_attr);
+	if (ret) {
+		pr_err("sysfs_create_bin_file() failed for for file: %s\n",
+			ts_tbl_bin_attr.attr.name);
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
+static void __exit cb_ts_tbl_exit(void)
+{
+	sysfs_remove_bin_file(cb_kobj, &ts_tbl_bin_attr);
+
+	if (ts_tbl_buf)
+		kfree(ts_tbl_buf);
+} 
+
+module_init(cb_ts_tbl_init);
+module_exit(cb_ts_tbl_exit);
+
+MODULE_AUTHOR("Oleksii Kurochko<oleksii.kurochko@gmail.com>");
+MODULE_LICENSE("GPL");

--- a/drivers/firmware/coreboot/timestamp.h
+++ b/drivers/firmware/coreboot/timestamp.h
@@ -1,0 +1,246 @@
+/*
+ * This file is part of the coreboot project.
+ *
+ * Copyright (C) 2011 The ChromiumOS Authors.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef __TIMESTAMP_SERIALIZED_H__
+#define __TIMESTAMP_SERIALIZED_H__
+
+struct timestamp_entry {
+	uint32_t	entry_id;
+	uint64_t	entry_stamp;
+} __packed;
+
+struct timestamp_table {
+	uint64_t	base_time;
+	uint16_t	max_entries;
+	uint16_t	tick_freq_mhz;
+	uint32_t	num_entries;
+	struct timestamp_entry entries[0]; /* Variable number of entries */
+} __packed;
+
+enum timestamp_id {
+	TS_START_ROMSTAGE = 1,
+	TS_BEFORE_INITRAM = 2,
+	TS_AFTER_INITRAM = 3,
+	TS_END_ROMSTAGE = 4,
+	TS_START_VBOOT = 5,
+	TS_END_VBOOT = 6,
+	TS_START_COPYRAM = 8,
+	TS_END_COPYRAM = 9,
+	TS_START_RAMSTAGE = 10,
+	TS_START_BOOTBLOCK = 11,
+	TS_END_BOOTBLOCK = 12,
+	TS_START_COPYROM = 13,
+	TS_END_COPYROM = 14,
+	TS_START_ULZMA = 15,
+	TS_END_ULZMA = 16,
+	TS_START_ULZ4F = 17,
+	TS_END_ULZ4F = 18,
+	TS_DEVICE_ENUMERATE = 30,
+	TS_DEVICE_CONFIGURE = 40,
+	TS_DEVICE_ENABLE = 50,
+	TS_DEVICE_INITIALIZE = 60,
+	TS_OPROM_INITIALIZE = 65,
+	TS_OPROM_COPY_END = 66,
+	TS_OPROM_END = 67,
+	TS_DEVICE_DONE = 70,
+	TS_CBMEM_POST = 75,
+	TS_WRITE_TABLES = 80,
+	TS_FINALIZE_CHIPS = 85,
+	TS_LOAD_PAYLOAD = 90,
+	TS_ACPI_WAKE_JUMP = 98,
+	TS_SELFBOOT_JUMP = 99,
+
+	/* 500+ reserved for vendorcode extensions (500-600: google/chromeos) */
+	TS_START_COPYVER = 501,
+	TS_END_COPYVER = 502,
+	TS_START_TPMINIT = 503,
+	TS_END_TPMINIT = 504,
+	TS_START_VERIFY_SLOT = 505,
+	TS_END_VERIFY_SLOT = 506,
+	TS_START_HASH_BODY = 507,
+	TS_DONE_LOADING = 508,
+	TS_DONE_HASHING = 509,
+	TS_END_HASH_BODY = 510,
+	TS_START_COPYVPD = 550,
+	TS_END_COPYVPD_RO = 551,
+	TS_END_COPYVPD_RW = 552,
+
+	/* 900-920 reserved for vendorcode extensions (900-940: AMD AGESA) */
+	TS_AGESA_INIT_RESET_START = 900,
+	TS_AGESA_INIT_RESET_DONE = 901,
+	TS_AGESA_INIT_EARLY_START = 902,
+	TS_AGESA_INIT_EARLY_DONE = 903,
+	TS_AGESA_INIT_POST_START = 904,
+	TS_AGESA_INIT_POST_DONE = 905,
+	TS_AGESA_INIT_ENV_START = 906,
+	TS_AGESA_INIT_ENV_DONE = 907,
+	TS_AGESA_INIT_MID_START = 908,
+	TS_AGESA_INIT_MID_DONE = 909,
+	TS_AGESA_INIT_LATE_START = 910,
+	TS_AGESA_INIT_LATE_DONE = 911,
+	TS_AGESA_INIT_RTB_START = 912,
+	TS_AGESA_INIT_RTB_DONE = 913,
+	TS_AGESA_INIT_RESUME_START = 914,
+	TS_AGESA_INIT_RESUME_DONE = 915,
+	TS_AGESA_S3_LATE_START = 916,
+	TS_AGESA_S3_LATE_DONE = 917,
+	TS_AGESA_S3_FINAL_START = 918,
+	TS_AGESA_S3_FINAL_DONE = 919,
+
+	/* 940-950 reserved for vendorcode extensions (940-950: Intel ME) */
+	TS_ME_INFORM_DRAM_WAIT = 940,
+	TS_ME_INFORM_DRAM_DONE = 941,
+
+	/* 950+ reserved for vendorcode extensions (950-999: intel/fsp) */
+	TS_FSP_MEMORY_INIT_START = 950,
+	TS_FSP_MEMORY_INIT_END = 951,
+	TS_FSP_TEMP_RAM_EXIT_START = 952,
+	TS_FSP_TEMP_RAM_EXIT_END = 953,
+	TS_FSP_SILICON_INIT_START = 954,
+	TS_FSP_SILICON_INIT_END = 955,
+	TS_FSP_BEFORE_ENUMERATE = 956,
+	TS_FSP_AFTER_ENUMERATE = 957,
+	TS_FSP_BEFORE_FINALIZE = 958,
+	TS_FSP_AFTER_FINALIZE = 959,
+	TS_FSP_BEFORE_END_OF_FIRMWARE = 960,
+	TS_FSP_AFTER_END_OF_FIRMWARE = 961,
+
+	/* 1000+ reserved for payloads (1000-1200: ChromeOS depthcharge) */
+
+	/* Depthcharge entry IDs start at 1000 */
+	TS_DC_START = 1000,
+
+	TS_RO_PARAMS_INIT = 1001,
+	TS_RO_VB_INIT = 1002,
+	TS_RO_VB_SELECT_FIRMWARE = 1003,
+	TS_RO_VB_SELECT_AND_LOAD_KERNEL = 1004,
+
+	TS_RW_VB_SELECT_AND_LOAD_KERNEL = 1010,
+
+	TS_VB_SELECT_AND_LOAD_KERNEL = 1020,
+	TS_VB_EC_VBOOT_DONE = 1030,
+	TS_VB_STORAGE_INIT_DONE = 1040,
+	TS_VB_READ_KERNEL_DONE = 1050,
+	TS_VB_VBOOT_DONE = 1100,
+
+	TS_START_KERNEL = 1101,
+	TS_KERNEL_DECOMPRESSION = 1102,
+};
+
+static const struct timestamp_id_to_name {
+	uint32_t id;
+	const char *name;
+} timestamp_ids[] = {
+	/* Marker to report base_time. */
+	{ 0,			"1st timestamp" },
+	{ TS_START_ROMSTAGE,	"start of romstage" },
+	{ TS_BEFORE_INITRAM,	"before ram initialization" },
+	{ TS_AFTER_INITRAM,	"after ram initialization" },
+	{ TS_END_ROMSTAGE,	"end of romstage" },
+	{ TS_START_VBOOT,	"start of verified boot" },
+	{ TS_END_VBOOT,		"end of verified boot" },
+	{ TS_START_COPYRAM,	"starting to load ramstage" },
+	{ TS_END_COPYRAM,	"finished loading ramstage" },
+	{ TS_START_RAMSTAGE,	"start of ramstage" },
+	{ TS_START_BOOTBLOCK,	"start of bootblock" },
+	{ TS_END_BOOTBLOCK,	"end of bootblock" },
+	{ TS_START_COPYROM,	"starting to load romstage" },
+	{ TS_END_COPYROM,	"finished loading romstage" },
+	{ TS_START_ULZMA,	"starting LZMA decompress (ignore for x86)" },
+	{ TS_END_ULZMA,		"finished LZMA decompress (ignore for x86)" },
+	{ TS_START_ULZ4F,	"starting LZ4 decompress (ignore for x86)" },
+	{ TS_END_ULZ4F,		"finished LZ4 decompress (ignore for x86)" },
+	{ TS_DEVICE_ENUMERATE,	"device enumeration" },
+	{ TS_DEVICE_CONFIGURE,	"device configuration" },
+	{ TS_DEVICE_ENABLE,	"device enable" },
+	{ TS_DEVICE_INITIALIZE,	"device initialization" },
+	{ TS_OPROM_INITIALIZE,	"Option ROM initialization" },
+	{ TS_OPROM_COPY_END,	"Option ROM copy done" },
+	{ TS_OPROM_END,		"Option ROM run done"   },
+	{ TS_DEVICE_DONE,	"device setup done" },
+	{ TS_CBMEM_POST,	"cbmem post" },
+	{ TS_WRITE_TABLES,	"write tables" },
+	{ TS_FINALIZE_CHIPS,	"finalize chips" },
+	{ TS_LOAD_PAYLOAD,	"load payload" },
+	{ TS_ACPI_WAKE_JUMP,	"ACPI wake jump" },
+	{ TS_SELFBOOT_JUMP,	"selfboot jump" },
+
+	{ TS_START_COPYVER,	"starting to load verstage" },
+	{ TS_END_COPYVER,	"finished loading verstage" },
+	{ TS_START_TPMINIT,	"starting to initialize TPM" },
+	{ TS_END_TPMINIT,	"finished TPM initialization" },
+	{ TS_START_VERIFY_SLOT,	"starting to verify keyblock/preamble (RSA)" },
+	{ TS_END_VERIFY_SLOT,	"finished verifying keyblock/preamble (RSA)" },
+	{ TS_START_HASH_BODY,	"starting to verify body (load+SHA2+RSA) " },
+	{ TS_DONE_LOADING,	"finished loading body (ignore for x86)" },
+	{ TS_DONE_HASHING,	"finished calculating body hash (SHA2)" },
+	{ TS_END_HASH_BODY,	"finished verifying body signature (RSA)" },
+
+	{ TS_START_COPYVPD,	"starting to load Chrome OS VPD" },
+	{ TS_END_COPYVPD_RO,	"finished loading Chrome OS VPD (RO)" },
+	{ TS_END_COPYVPD_RW,	"finished loading Chrome OS VPD (RW)" },
+
+	{ TS_DC_START,		"depthcharge start" },
+	{ TS_RO_PARAMS_INIT,	"RO parameter init" },
+	{ TS_RO_VB_INIT,	"RO vboot init" },
+	{ TS_RO_VB_SELECT_FIRMWARE,		"RO vboot select firmware" },
+	{ TS_RO_VB_SELECT_AND_LOAD_KERNEL,	"RO vboot select&load kernel" },
+	{ TS_RW_VB_SELECT_AND_LOAD_KERNEL,	"RW vboot select&load kernel" },
+	{ TS_VB_SELECT_AND_LOAD_KERNEL,		"vboot select&load kernel" },
+	{ TS_VB_EC_VBOOT_DONE,	"finished EC verification" },
+	{ TS_VB_STORAGE_INIT_DONE, "finished storage device initialization" },
+	{ TS_VB_READ_KERNEL_DONE, "finished reading kernel from disk" },
+	{ TS_VB_VBOOT_DONE,	"finished vboot kernel verification" },
+	{ TS_KERNEL_DECOMPRESSION, "starting kernel decompression/relocation" },
+	{ TS_START_KERNEL,	"jumping to kernel" },
+
+	/* AMD AGESA related timestamps */
+	{ TS_AGESA_INIT_RESET_START,	"calling AmdInitReset" },
+	{ TS_AGESA_INIT_RESET_DONE,	"back from AmdInitReset" },
+	{ TS_AGESA_INIT_EARLY_START,	"calling AmdInitEarly" },
+	{ TS_AGESA_INIT_EARLY_DONE,	"back from AmdInitEarly" },
+	{ TS_AGESA_INIT_POST_START,	"calling AmdInitPost" },
+	{ TS_AGESA_INIT_POST_DONE,	"back from AmdInitPost" },
+	{ TS_AGESA_INIT_ENV_START,	"calling AmdInitEnv" },
+	{ TS_AGESA_INIT_ENV_DONE,	"back from AmdInitEnv" },
+	{ TS_AGESA_INIT_MID_START,	"calling AmdInitMid" },
+	{ TS_AGESA_INIT_MID_DONE,	"back from AmdInitMid" },
+	{ TS_AGESA_INIT_LATE_START,	"calling AmdInitLate" },
+	{ TS_AGESA_INIT_LATE_DONE,	"back from AmdInitLate" },
+	{ TS_AGESA_INIT_RTB_START,	"calling AmdInitRtb/AmdS3Save" },
+	{ TS_AGESA_INIT_RTB_DONE,	"back from AmdInitRtb/AmdS3Save" },
+
+	/* Intel ME related timestamps */
+	{ TS_ME_INFORM_DRAM_WAIT,	"waiting for ME acknowledgement of raminit"},
+	{ TS_ME_INFORM_DRAM_DONE,	"finished waiting for ME response"},
+
+	/* FSP related timestamps */
+	{ TS_FSP_MEMORY_INIT_START, "calling FspMemoryInit" },
+	{ TS_FSP_MEMORY_INIT_END, "returning from FspMemoryInit" },
+	{ TS_FSP_TEMP_RAM_EXIT_START, "calling FspTempRamExit" },
+	{ TS_FSP_TEMP_RAM_EXIT_END, "returning from FspTempRamExit" },
+	{ TS_FSP_SILICON_INIT_START, "calling FspSiliconInit" },
+	{ TS_FSP_SILICON_INIT_END, "returning from FspSiliconInit" },
+	{ TS_FSP_BEFORE_ENUMERATE, "calling FspNotify(AfterPciEnumeration)" },
+	{ TS_FSP_AFTER_ENUMERATE,
+		 "returning from FspNotify(AfterPciEnumeration)" },
+	{ TS_FSP_BEFORE_FINALIZE, "calling FspNotify(ReadyToBoot)" },
+	{ TS_FSP_AFTER_FINALIZE, "returning from FspNotify(ReadyToBoot)" },
+	{ TS_FSP_BEFORE_END_OF_FIRMWARE, "calling FspNotify(EndOfFirmware)" },
+	{ TS_FSP_AFTER_END_OF_FIRMWARE,
+		"returning from FspNotify(EndOfFirmware)" },
+};
+
+#endif


### PR DESCRIPTION
All coreboot timestamps table related information is exported to
/sys/firmware/coreboot/timestamps

Signed-off-by: Oleksii Kurochko <oleksii.kurochko@gmail.com>